### PR TITLE
robots.txt

### DIFF
--- a/public/robots.txt
+++ b/public/robots.txt
@@ -1,21 +1,10 @@
-# robots.txt für https://karte.openstreetmap.de/
-# Diese Datei steuert, welche Bereiche Suchmaschinen crawlen dürfen.
+# robots.txt for https://karte.openstreetmap.de/
 
-# Gilt für alle Suchmaschinen
+# Applies to all search engines
 User-agent: *
 
-# Verhindert das Crawlen aller Verzeichnisse (alle Pfade mit mindestens einem Slash)
+# Prevents crawling of all directories (all paths with at least one slash)
 Disallow: /*/
 
-# Erlaubt ausdrücklich die Startseite und alle Ressourcen direkt im Root (z.B. /index.html, /logo.png)
+# Explicitly allows the homepage and all resources directly in the root (e.g., /index.html, /favicon.svg ...)
 Allow: /
-
-###
-# Wir möchten später das Verzeichnis /beispielverzeichnis/ und dessen Inhalte erlauben.
-###
-
-# Erlaubt den Zugriff auf /beispielverzeichnis/ selbst
-# Allow: /beispielverzeichnis/
-
-# Erlaubt den Zugriff auf alle Inhalte innerhalb von /beispielverzeichnis/
-# Allow: /beispielverzeichnis/*

--- a/public/robots.txt
+++ b/public/robots.txt
@@ -1,0 +1,21 @@
+# robots.txt für https://karte.openstreetmap.de/
+# Diese Datei steuert, welche Bereiche Suchmaschinen crawlen dürfen.
+
+# Gilt für alle Suchmaschinen
+User-agent: *
+
+# Verhindert das Crawlen aller Verzeichnisse (alle Pfade mit mindestens einem Slash)
+Disallow: /*/
+
+# Erlaubt ausdrücklich die Startseite und alle Ressourcen direkt im Root (z.B. /index.html, /logo.png)
+Allow: /
+
+###
+# Wir möchten später das Verzeichnis /beispielverzeichnis/ und dessen Inhalte erlauben.
+###
+
+# Erlaubt den Zugriff auf /beispielverzeichnis/ selbst
+# Allow: /beispielverzeichnis/
+
+# Erlaubt den Zugriff auf alle Inhalte innerhalb von /beispielverzeichnis/
+# Allow: /beispielverzeichnis/*


### PR DESCRIPTION
Ich habe die robots.txt bewusst sehr restriktiv gestaltet, um zu verhindern, dass Suchmaschinen die durch die Anwendung erzeugten URLs wie `/map/zoom/lat/lon` crawlen und indexieren. Diese Pfade entstehen technisch durch wenn wir die hash nutzen und führen lediglich zu unterschiedlichen Kartenausschnitten, bieten aber keinen eigenständigen, relevanten Content für Suchmaschinen.

Eine Indexierung solcher URLs hätte, wenn ich das richtig sehe, negative Auswirkungen auf SEO, da sie Duplicate Content erzeugen, das Crawl-Budget unnötig belasten und keine sinnvollen Suchergebnisse liefern würden. 


- fixes https://github.com/fossgis/karte.openstreetmap.de/issues/12