### PR TITLE
Einbinden der JavaScript- und CSS-Dateien

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,7 +26,10 @@ biome check
 biome check --fix
 ```
 
-## External libraries
+## Libraries
+
+Including many JavaScript and CSS files with `<script>` and `<link>` tags can make `index.html` messy. Instead, we use `@import` in `index.css` and `import` in `index.js`, so that only these two files need to be included in the HTML.
+
+### External libraries
 
 External libraries shall be downloaded to `public/lib/<add-official-name-of-library>` and added to the git repo.
-

--- a/public/index.css
+++ b/public/index.css
@@ -1,3 +1,5 @@
+@import "./lib/maplibre-gl/maplibre-gl.css";
+
 body {
   margin: 0;
   padding: 0;

--- a/public/index.html
+++ b/public/index.html
@@ -11,11 +11,6 @@
     <link rel="manifest" href="/site.webmanifest">
    <meta name="description" content="OpenStreetMap ist eine frei editierbare Weltkarte, erstellt von einer globalen Community – offen, kostenlos, für alle.">
     
-    <!-- external JS and CSS -->
-    <script src="/lib/maplibre-gl/maplibre-gl.js"></script>
-    <link href="/lib/maplibre-gl/maplibre-gl.css" rel="stylesheet" />
-    
-    <!-- local JS and CSS-->
     <link rel="stylesheet" href="index.css">
     <script type="module" src="index.js" defer></script>
 </head>

--- a/public/index.js
+++ b/public/index.js
@@ -1,3 +1,5 @@
+import "./lib/maplibre-gl/maplibre-gl.js";
+
 const style = {
   version: 8,
   sources: {


### PR DESCRIPTION
Das Einbinden mehrerer JavaScript- und CSS-Dateien über `<script>-` und `<link>`-Tags kann eine `index.html` schnell unübersichtlich machen. Daher integrieren wir diese Dateien stattdessen mit `@import` in die `index.css `beziehungsweise mit `import` in die `index.js`. So brauchen wir in der index.html nur zwei Importe.

https://github.com/fossgis/karte.openstreetmap.de/issues/22
Close #22

