### PR TITLE
Display full attribution by default

### DIFF
--- a/public/index.js
+++ b/public/index.js
@@ -32,6 +32,6 @@ new maplibregl.Map({
   dragRotate: false,
   touchZoomRotate: false,
   attributionControl: {
-    compact: false
-  }
+    compact: false,
+  },
 });

--- a/public/index.js
+++ b/public/index.js
@@ -31,4 +31,7 @@ new maplibregl.Map({
   maplibreLogo: false,
   dragRotate: false,
   touchZoomRotate: false,
+  attributionControl: {
+    compact: false
+  }
 });


### PR DESCRIPTION
- Zeigt die standard-mäßig die gesamte Attribution der Landkarte 
- fixes #5 

<img width="1205" height="956" alt="image" src="https://github.com/user-attachments/assets/e48d6864-8406-4768-8bb4-207bfce1a7df" />
