### PR TITLE
Permalink

### DIFF
--- a/public/index.js
+++ b/public/index.js
@@ -30,7 +30,7 @@ const map = new maplibregl.Map({
   container: "map",
   bounds: boundsGermany,
   style: style,
-  hash: "p",
+  hash: "map",
   maplibreLogo: false,
   dragRotate: false,
   touchZoomRotate: false,


### PR DESCRIPTION
`hash: "osmdeHash"` = z.B. `.../#osmdeHash=5.54/51.723/10.5` als URL
oder
`hash: true` = z.B. `.../#4.68/51.72/10.5` als URL.

Ich schlage vor, den Permalink als Hashstring hinzuzufügen (https://github.com/maplibre/maplibre-gl-js/blob/7887f2c899dcc7f7bfa8a05f5a98c92bf1a5bf5a/src/ui/map.ts#L89).


Nachteil des `Strings` anstelle von `true`
- längere URL

Vorteil
- wir haben die Möglichkeit, später auch Layer im [Fragment](https://de.wikipedia.org/wiki/Fragmentbezeichner) zu übergeben. 
- mehrere Maps auf einer Website sind möglich


Close https://github.com/fossgis/karte.openstreetmap.de/issues/6