### PR TITLE
Use the default settings from attribution control

### DIFF
--- a/public/index.js
+++ b/public/index.js
@@ -33,9 +33,7 @@ const map = new maplibregl.Map({
   maplibreLogo: false,
   dragRotate: false,
   touchZoomRotate: false,
-  attributionControl: {
-    compact: false,
-  },
+  attributionControl: true,
 });
 
 map.addControl(new maplibregl.ScaleControl({}));


### PR DESCRIPTION
nutzt die Default-Einstellungen der Attribution Control wie in https://github.com/fossgis/karte.openstreetmap.de/issues/10#issuecomment-3148722585 vorgeschlagen.