### PR TITLE
Navigation Control

### DIFF
--- a/public/index.js
+++ b/public/index.js
@@ -37,6 +37,10 @@ const map = new maplibregl.Map({
   attributionControl: true,
 });
 
+if (window.matchMedia("(min-width: 640px)").matches) {
+  map.addControl(new maplibregl.NavigationControl(), "top-right");
+}
+
 map.addControl(new maplibregl.ScaleControl());
 
 map.addControl(new maplibregl.GeolocateControl());


### PR DESCRIPTION
Das `NavigationControl` wird mit diesem PR auf breiten Bildschirmen eingeblendet.
Es wird bei einer Bildschirmbreite von **mindestens 640px** hinzugefügt, auf kleineren Viewports dagegen nicht.
`window.matchMedia` reagiert nicht dynamisch auf spätere Größenänderungen, sondern prüft nur beim Laden.


Close https://github.com/fossgis/karte.openstreetmap.de/issues/39