### PR TITLE
Limit zoom to level 19

### DIFF
--- a/public/index.js
+++ b/public/index.js
@@ -33,7 +33,7 @@ const map = new maplibregl.Map({
   dragRotate: false,
   touchZoomRotate: false,
   attributionControl: true,
-  maxZoom: 19, 
+  maxZoom: 19,
   locale: {
     "AttributionControl.ToggleAttribution": "Quellenangabe ein-/ausblenden",
     "GeolocateControl.FindMyLocation": "Meinen Standort finden",


### PR DESCRIPTION
Verhindert das Karte weiter als Zoomstufe 19 gezoomt wird. Die von uns genutzt Basemap kann nämlich nur bis Stufe 19