### PR TITLE
Hintergrundkarte in URL als Permalink speichern

### DIFF
--- a/public/lib/internal/BasemapSwitcher.js
+++ b/public/lib/internal/BasemapSwitcher.js
@@ -13,7 +13,8 @@ export class BasemapSwitcher {
     // initial basemap settings
     const existingLayerIds = Object.keys(this._basemapConfig);
     const firstLayerIdInConfig = existingLayerIds[0];
-    this._initialLayerId = this._getValidLayerIdFromUrl() || firstLayerIdInConfig;
+    this._initialLayerId =
+      this._getValidLayerIdFromUrl() || firstLayerIdInConfig;
     this._visibleId = this._initialLayerId;
 
     // setup html elements


### PR DESCRIPTION
- fixes #57 
- speichert angezeigten Hintergrundkarte in URL als Permalink. Beispiel: `karte.openstreetmap.de/#map=5.23/51.723/10.5&layer=cyclosm`
- [ ] Der Key für die Hintergrundkarte in der URL ist derzeit `layer`, können wir aber gerne auf etwas Anderes ändern