### PR TITLE
Remove uneeded geocoder container from navigation menu

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -54,7 +54,6 @@
       <!-- Main navigation menu -->
       <nav class="nav">
         <ul class="nav-list">
-          <li id="geocoder-container"></li>
           <li class="dropdown">
             <input
               type="checkbox"


### PR DESCRIPTION
entfernt toten Code der versehentlich hier https://github.com/fossgis/karte.openstreetmap.de/pull/52 eingefügt wurde