### PR TITLE
Hide basemap menu also when user move map

### DIFF
--- a/public/lib/internal/BasemapSwitcher.js
+++ b/public/lib/internal/BasemapSwitcher.js
@@ -48,12 +48,12 @@ export class BasemapSwitcher {
     });
 
     // hide basemap cards, when user clicks anywhere
-    document.addEventListener("click", () => {
+    document.addEventListener("pointerdown", () => {
       basemapOptions.classList.add("hidden");
     });
 
     // prevent hiding when user clicks on card again
-    basemapOptions.addEventListener("click", (event) => {
+    basemapOptions.addEventListener("pointerdown", (event) => {
       event.stopPropagation();
     });
 


### PR DESCRIPTION
Das ist ein kleiner Fix.

Vorher: 
Wenn das Basemap-Menü geöffnet war, dann wurde es geschlossen, wenn der User irgendwo anders hingeklick hat. AUSSER, wenn der User die Karte verschoben hat.

Jetzt:
Geöffnetes Basemap Menü wird auch geöffnet wenn User Karte verschiebt.