### PR TITLE
Map control harmonisation

### DIFF
--- a/public/icons/layer.svg
+++ b/public/icons/layer.svg
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?><!-- Uploaded to: SVG Repo, www.svgrepo.com, Generator: SVG Repo Mixer Tools -->
-<svg viewBox="0 0 24 24" fill="none" xmlns="http://www.w3.org/2000/svg">
+<svg xmlns="http://www.w3.org/2000/svg" width="22" height="22" fill="none" viewBox="0 0 24 24">
 <path d="M4 8L12 4L20 8L12 12L4 8Z" stroke="#000000" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"/>
 <path d="M4 12L12 16L20 12" stroke="#000000" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"/>
 <path d="M4 16L12 20L20 16" stroke="#000000" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"/>

--- a/public/index.css
+++ b/public/index.css
@@ -159,6 +159,11 @@ a {
   display: none;
 }
 
+.maplibregl-ctrl-group button {
+  width: 36px;
+  height: 36px;
+}
+
 @media (max-width: 768px) {
   .hamburger-menu {
     display: block;

--- a/public/index.css
+++ b/public/index.css
@@ -165,6 +165,10 @@ a {
   height: 36px;
 }
 
+.maplibregl-ctrl-geocoder--icon {
+  fill: black;
+}
+
 @media (max-width: 768px) {
   .hamburger-menu {
     display: block;

--- a/public/index.css
+++ b/public/index.css
@@ -159,6 +159,7 @@ a {
   display: none;
 }
 
+/* match size of search icon */
 .maplibregl-ctrl-group button {
   width: 36px;
   height: 36px;

--- a/public/lib/internal/search.js
+++ b/public/lib/internal/search.js
@@ -129,6 +129,7 @@ export function createSearchControl(mapInstance) {
     maplibregl: mapInstance,
     limit: countDisplayedResults,
     language: defaultLanguage,
+    collapsed: true,
 
     // needed for autocomplete
     showResultsWhileTyping: true,


### PR DESCRIPTION
- collapse the search bar by default
- make the search icon black to match the colors of the other controls
- ensure the "switch layer" icon keeps the same size on mobile. Before it became bigger and looked inconsistent


<img width="1229" height="839" alt="image" src="https://github.com/user-attachments/assets/f79961ac-563e-466d-a418-13882dcf517d" />


<img width="1238" height="812" alt="image" src="https://github.com/user-attachments/assets/09be630f-9294-4739-a2fd-fa058a5ebf8f" />
